### PR TITLE
Set natural-direct prose style for Project issues

### DIFF
--- a/.projects/project.md
+++ b/.projects/project.md
@@ -11,6 +11,7 @@
 | Routing | Project membership; no routing label |
 | Privacy | public repository with a private Project |
 | Issue write-up style | tidy |
+| Issue prose style | natural-direct |
 
 ## Field locations
 


### PR DESCRIPTION
Set `Issue prose style | natural-direct` in the resolved Project contract. The existing `tidy` write-up level stays unchanged.

Refs MiguelRodo/projects#120